### PR TITLE
Enqueue Font Awesome for use

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -120,3 +120,12 @@ function _s_category_transient_flusher() {
 }
 add_action( 'edit_category', '_s_category_transient_flusher' );
 add_action( 'save_post',     '_s_category_transient_flusher' );
+
+/**
+ * Enqueue Font Awesome for use in WP Admin and Template
+ */
+function _s_load_fa_icons() {
+	wp_enqueue_style( '_s_fa_icons', 'https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css' );
+}
+add_action( 'admin_enqueue_scripts', '_s_load_fa_icons' );
+add_action( 'wp_enqueue_scripts', '_s_load_fa_icons' );


### PR DESCRIPTION
This does not add to the core functionality of _S theme but I think it is becoming a "necessary evil". Since DashIcons is not increasing the number of growing social media icons and several others, developers feel like they need to have the freedom to express their work with more icons. Enqueueing Font Awesome for use in WP Admin and Template would help a lot to solve this issue.